### PR TITLE
Explicit '__all__' for `MultiFactorAuthSerializer`

### DIFF
--- a/deux/serializers.py
+++ b/deux/serializers.py
@@ -39,6 +39,7 @@ class MultiFactorAuthSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = mfa_settings.MFA_MODEL
+        fields = '__all__'
 
 
 class _BaseChallengeRequestSerializer(MultiFactorAuthSerializer):


### PR DESCRIPTION
Since django-rest-framework 3.3.0
```AssertionError: ("Creating a ModelSerializer without either the 'fields' attribute or the 'exclude' attribute has been deprecated since 3.3.0, and is now disallowed. Add an explicit fields = 'all' to the MultiFactorAuthSerializer serializer.",)```
This explicit changes would remove this error.